### PR TITLE
Fix staff avatar images

### DIFF
--- a/ranks_staff/index.html
+++ b/ranks_staff/index.html
@@ -77,61 +77,61 @@
 		</dd> <dt class="col-sm-3 col-md-2">Retired:</dt> <dd class="col-sm-9 col-md-10">Someone who used to be on the staff team but is no longer.</dd> <dt class="col-sm-3 col-md-2">Legendary:</dt> <dd class="col-sm-9 col-md-10">
 			Someone who has had a large and positive impact on the server and/or the community, but no longer
 			regularly participates, sometimes having left entirely.
-		</dd></dl> <h2 id="staff">Our Staff</h2> <table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Owner</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>Remi</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/7e55e238-6225-4b32-9a49-5ad7676ba121/32" alt="Remi_Scarlet">
+		</dd></dl> <h2 id="staff">Our Staff</h2> <table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Owner</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>Remi</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/7e55e23862254b329a495ad7676ba121/32" alt="Remi_Scarlet">
 						Remi_Scarlet
-					</li><li><img src="https://mc-heads.net/avatar/2100d93b-87e4-46f0-9479-affde3e5b02f/32" alt="DivineAquaSama">
+					</li><li><img src="https://mc-heads.net/avatar/2100d93b87e446f09479affde3e5b02f/32" alt="DivineAquaSama">
 						DivineAquaSama
-					</li><li><img src="https://mc-heads.net/avatar/9f3ee4af-34de-4943-9a84-45d713778b4c/32" alt="7h3d4rkw0lf">
+					</li><li><img src="https://mc-heads.net/avatar/9f3ee4af34de49439a8445d713778b4c/32" alt="7h3d4rkw0lf">
 						7h3d4rkw0lf
-					</li><li><img src="https://mc-heads.net/avatar/0e359afb-770e-4f6f-9e64-ab4633f8b91c/32" alt="Kanzaki_Ranran">
+					</li><li><img src="https://mc-heads.net/avatar/0e359afb770e4f6f9e64ab4633f8b91c/32" alt="Kanzaki_Ranran">
 						Kanzaki_Ranran
-					</li></ul></td> <td>The main owner that you see around most of the time.</td></tr><tr><td>msm595</td> <td><div><img src="https://mc-heads.net/avatar/9bbedf09-712d-4e0a-a241-4e946c63a22e/32" alt="msm595">
+					</li></ul></td> <td>The main owner that you see around most of the time.</td></tr><tr><td>msm595</td> <td><div><img src="https://mc-heads.net/avatar/9bbedf09712d4e0aa2414e946c63a22e/32" alt="msm595">
 					msm595
-				</div></td> <td>The other owner who never comes on. Something something real adult responsibility things.</td></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Admins</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>Cyros</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/e48a9755-b091-4b2c-a3ae-98da341924f6/32" alt="Cyros_Lugoth">
+				</div></td> <td>The other owner who never comes on. Something something real adult responsibility things.</td></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Admins</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>Cyros</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/e48a9755b0914b2ca3ae98da341924f6/32" alt="Cyros_Lugoth">
 						Cyros_Lugoth
-					</li><li><img src="https://mc-heads.net/avatar/675b6e35-0147-4cf9-9709-daf6fa8ac972/32" alt="Komeiji_Koishi">
+					</li><li><img src="https://mc-heads.net/avatar/675b6e3501474cf99709daf6fa8ac972/32" alt="Komeiji_Koishi">
 						Komeiji_Koishi
-					</li><li><img src="https://mc-heads.net/avatar/47515849-e82d-4412-b25e-b4d76b4b5443/32" alt="Seija_Kijin">
+					</li><li><img src="https://mc-heads.net/avatar/47515849e82d4412b25eb4d76b4b5443/32" alt="Seija_Kijin">
 						Seija_Kijin
-					</li></ul></td> <td>Wait... What am I doing again?</td></tr><tr><td>Teshno</td> <td><div><img src="https://mc-heads.net/avatar/225895ef-fdaf-4403-ba6c-d4fe6fd6bdbc/32" alt="Teshno">
+					</li></ul></td> <td>Wait... What am I doing again?</td></tr><tr><td>Teshno</td> <td><div><img src="https://mc-heads.net/avatar/225895effdaf4403ba6cd4fe6fd6bdbc/32" alt="Teshno">
 					Teshno
-				</div></td> <td>cawfee</td></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Sysadmins</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>Tsunko</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/434d8cf1-3fa2-43bf-9e12-dbeb485d90a8/32" alt="Hinanawi__Tenshi">
+				</div></td> <td>cawfee</td></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Sysadmins</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>Tsunko</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/434d8cf13fa243bf9e12dbeb485d90a8/32" alt="Hinanawi__Tenshi">
 						Hinanawi__Tenshi
-					</li><li><img src="https://mc-heads.net/avatar/27028066-b53a-4c0d-9aca-14f29a51e111/32" alt="TsunkoH">
+					</li><li><img src="https://mc-heads.net/avatar/27028066b53a4c0d9aca14f29a51e111/32" alt="TsunkoH">
 						TsunkoH
-					</li><li><img src="https://mc-heads.net/avatar/49c7b314-3164-423c-8e66-182839f6f7a7/32" alt="JohnnyPussyFists">
+					</li><li><img src="https://mc-heads.net/avatar/49c7b3143164423c8e66182839f6f7a7/32" alt="JohnnyPussyFists">
 						JohnnyPussyFists
-					</li></ul></td> <td>Youkaipeach. Also, Tenshi &lt;3</td></tr><tr><td>Katrix</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/9c36eef0-c7ed-4eaf-99f7-984ff7c0a794/32" alt="Kogasa_Tatara">
+					</li></ul></td> <td>Youkaipeach. Also, Tenshi &lt;3</td></tr><tr><td>Katrix</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/9c36eef0c7ed4eaf99f7984ff7c0a794/32" alt="Kogasa_Tatara">
 						Kogasa_Tatara
-					</li><li><img src="https://mc-heads.net/avatar/6611d165-54bb-4007-8dc5-cd4f6b168745/32" alt="Clownpiece_">
+					</li><li><img src="https://mc-heads.net/avatar/6611d16554bb40078dc5cd4f6b168745/32" alt="Clownpiece_">
 						Clownpiece_
-					</li><li><img src="https://mc-heads.net/avatar/a8c472e6-6d23-4122-8a49-3d44ac770364/32" alt="Komeiji_Satori">
+					</li><li><img src="https://mc-heads.net/avatar/a8c472e66d2341228a493d44ac770364/32" alt="Komeiji_Satori">
 						Komeiji_Satori
-					</li><li><img src="https://mc-heads.net/avatar/144337f3-85b8-4547-9721-a30f882d19bd/32" alt="Okina_Matara">
+					</li><li><img src="https://mc-heads.net/avatar/144337f385b845479721a30f882d19bd/32" alt="Okina_Matara">
 						Okina_Matara
-					</li></ul></td> <td>Our other sysadmin that cracks the whip for Remi and Tenshi.</td></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 80%;"></colgroup> <thead><tr><th colspan="1">Mediators</th> <th colspan="1">MC Accounts</th></tr></thead> <tr><td>0utlaw_X</td> <td><div><img src="https://mc-heads.net/avatar/9a662948-ae8c-4eba-b945-ddefa459fc5a/32" alt="0utlaw_X">
+					</li></ul></td> <td>Our other sysadmin that cracks the whip for Remi and Tenshi.</td></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 80%;"></colgroup> <thead><tr><th colspan="1">Mediators</th> <th colspan="1">MC Accounts</th></tr></thead> <tr><td>0utlaw_X</td> <td><div><img src="https://mc-heads.net/avatar/9a662948ae8c4ebab945ddefa459fc5a/32" alt="0utlaw_X">
 					0utlaw_X
-				</div></td> <!----></tr><tr><td>PhantomNerifes</td> <td><div><img src="https://mc-heads.net/avatar/458c0c72-fdec-4f95-859e-e3e475efb226/32" alt="PhantomNerifes">
+				</div></td> <!----></tr><tr><td>PhantomNerifes</td> <td><div><img src="https://mc-heads.net/avatar/458c0c72fdec4f95859ee3e475efb226/32" alt="PhantomNerifes">
 					PhantomNerifes
-				</div></td> <!----></tr><tr><td>Tewi_Inaba</td> <td><div><img src="https://mc-heads.net/avatar/d068bbb4-6280-4ddf-8c59-f1ee0b1af927/32" alt="Tewi_Inaba">
+				</div></td> <!----></tr><tr><td>Tewi_Inaba</td> <td><div><img src="https://mc-heads.net/avatar/d068bbb462804ddf8c59f1ee0b1af927/32" alt="Tewi_Inaba">
 					Tewi_Inaba
-				</div></td> <!----></tr><tr><td>Luna</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/06526838-2df6-425a-a418-b12c5bb6f524/32" alt="TRXD">
+				</div></td> <!----></tr><tr><td>Luna</td> <td><ul class="list-unstyled"><li><img src="https://mc-heads.net/avatar/065268382df6425aa418b12c5bb6f524/32" alt="TRXD">
 						TRXD
-					</li><li><img src="https://mc-heads.net/avatar/94ec4d00-abbf-40de-9258-66b027735131/32" alt="Trista_Lundin">
+					</li><li><img src="https://mc-heads.net/avatar/94ec4d00abbf40de925866b027735131/32" alt="Trista_Lundin">
 						Trista_Lundin
-					</li></ul></td> <!----></tr><tr><td>Tysonizer</td> <td><div><img src="https://mc-heads.net/avatar/7b98dcce-f94b-4433-9b42-44db6e1d843a/32" alt="Tysonizer">
+					</li></ul></td> <!----></tr><tr><td>Tysonizer</td> <td><div><img src="https://mc-heads.net/avatar/7b98dccef94b44339b4244db6e1d843a/32" alt="Tysonizer">
 					Tysonizer
-				</div></td> <!----></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 80%;"></colgroup> <thead><tr><th colspan="1">Builders</th> <th colspan="1">MC Accounts</th></tr></thead> <tr><td>Alayosho</td> <td><div><img src="https://mc-heads.net/avatar/8d73b291-4123-4698-b21d-0bc3bdd14e29/32" alt="Alayosho">
+				</div></td> <!----></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 80%;"></colgroup> <thead><tr><th colspan="1">Builders</th> <th colspan="1">MC Accounts</th></tr></thead> <tr><td>Alayosho</td> <td><div><img src="https://mc-heads.net/avatar/8d73b29141234698b21d0bc3bdd14e29/32" alt="Alayosho">
 					Alayosho
-				</div></td> <!----></tr><tr><td>Eiburine</td> <td><div><img src="https://mc-heads.net/avatar/c1f44a9f-f06c-4700-a78c-001074fb33f2/32" alt="Eiburine">
+				</div></td> <!----></tr><tr><td>Eiburine</td> <td><div><img src="https://mc-heads.net/avatar/c1f44a9ff06c4700a78c001074fb33f2/32" alt="Eiburine">
 					Eiburine
-				</div></td> <!----></tr><tr><td>KokoNuttz</td> <td><div><img src="https://mc-heads.net/avatar/e18aa899-1c62-41ad-acc4-2ef50e46114a/32" alt="KokoNuttz">
+				</div></td> <!----></tr><tr><td>KokoNuttz</td> <td><div><img src="https://mc-heads.net/avatar/e18aa8991c6241adacc42ef50e46114a/32" alt="KokoNuttz">
 					KokoNuttz
-				</div></td> <!----></tr><tr><td>qscgukp</td> <td><div><img src="https://mc-heads.net/avatar/04fdd713-7153-40a3-a6a5-f7d69be4f63b/32" alt="qscgukp">
+				</div></td> <!----></tr><tr><td>qscgukp</td> <td><div><img src="https://mc-heads.net/avatar/04fdd713715340a3a6a5f7d69be4f63b/32" alt="qscgukp">
 					qscgukp
-				</div></td> <!----></tr><tr><td>Redleaf64</td> <td><div><img src="https://mc-heads.net/avatar/a06791c1-5ccd-4894-9307-71818e119756/32" alt="Redleaf64">
+				</div></td> <!----></tr><tr><td>Redleaf64</td> <td><div><img src="https://mc-heads.net/avatar/a06791c15ccd4894930771818e119756/32" alt="Redleaf64">
 					Redleaf64
-				</div></td> <!----></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Misc</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>S121</td> <td><div><img src="https://mc-heads.net/avatar/10e9a380-6524-44b4-88b1-ee25514b5cf9/32" alt="S_121">
+				</div></td> <!----></tr></table><table class="table smaller-sm-text"><colgroup><col style="width: 20%;"> <col style="width: 30%;"> <col style="width: 50%;"></colgroup> <thead><tr><th colspan="1">Misc</th> <th colspan="2">MC Accounts</th></tr></thead> <tr><td>S121</td> <td><div><img src="https://mc-heads.net/avatar/10e9a380652444b488b1ee25514b5cf9/32" alt="S_121">
 					S_121
 				</div></td> <td>RP mod</td></tr></table> <p><strong><span style="font-size: xx-large; color: rgb(255, 0, 0);">DISCLAIMER:</span></strong> Mediators <em>do
 		not</em> have authority over builders, they are completely even ranks that do not overpower each other


### PR DESCRIPTION
mc-heads does not use dashes in the UUIDs for their images. Previously, this removal of dashes from UUIDs was handled by a script ("staffRenderer.js" while referencing "staff.json") but this function was seemingly forgotten about.
Unless/until this is reimplemented, I've provided a band-aid fix.